### PR TITLE
Bugfix: Read multiline secrets

### DIFF
--- a/src/main/java/com/onepassword/jenkins/plugins/OnePasswordAccessor.java
+++ b/src/main/java/com/onepassword/jenkins/plugins/OnePasswordAccessor.java
@@ -23,6 +23,7 @@ import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 public class OnePasswordAccessor implements Serializable {
 
@@ -126,7 +127,7 @@ public class OnePasswordAccessor implements Serializable {
                 Process pr = pb.command(commands).start();
                 BufferedReader stdInput = new BufferedReader(new InputStreamReader(pr.getInputStream(), StandardCharsets.UTF_8));
                 BufferedReader stdError = new BufferedReader(new InputStreamReader(pr.getErrorStream(), StandardCharsets.UTF_8));
-                String secretValue = stdInput.readLine();
+                String secretValue = stdInput.lines().collect(Collectors.joining(System.lineSeparator()));
                 if (StringUtils.isBlank(secretValue)) {
                     String s;
                     StringBuilder errorMessage = new StringBuilder();

--- a/src/test/java/com/onepassword/jenkins/plugins/OnePasswordWithSecretsTest.java
+++ b/src/test/java/com/onepassword/jenkins/plugins/OnePasswordWithSecretsTest.java
@@ -67,6 +67,20 @@ public class OnePasswordWithSecretsTest {
     }
 
     @Test
+    public void testSecretsMultiline() throws Exception {
+        WorkflowJob project = j.createProject(WorkflowJob.class);
+        project.setDefinition(new CpsFlowDefinition(readFile(basePath + "testSecretsMultiline.groovy",
+                Charset.defaultCharset())
+                .replace("OP_HOST", TEST_CONNECT_HOST)
+                .replace("OP_CLI_URL",OP_CLI_URL),
+                true));
+
+        WorkflowRun build = j.buildAndAssertSuccess(project);
+        j.assertLogContains(TEST_SUCCESS, build);
+        j.assertLogNotContains(TEST_FAILURE, build);
+    }
+
+    @Test
     public void testSecretsFromEnv() throws Exception {
         WorkflowJob project = j.createProject(WorkflowJob.class);
         project.setDefinition(new CpsFlowDefinition(readFile(basePath + "testSecretsFromEnv.groovy",

--- a/src/test/resources/com/onepassword/jenkins/plugins/pipeline/testSecretsMultiline.groovy
+++ b/src/test/resources/com/onepassword/jenkins/plugins/pipeline/testSecretsMultiline.groovy
@@ -1,0 +1,35 @@
+def config = [
+        connectHost: "OP_HOST",
+        connectCredentialId: "connect-credential-id"
+]
+
+def secrets = [
+        [envVar: 'MULTILINE_SECRET', secretRef: 'op://acceptance-tests/multiline-secret/notesPlain'],
+]
+
+node {
+    sh 'curl -sSfLo op.zip OP_CLI_URL && unzip -o op.zip && rm op.zip'
+    withSecrets(config: config, secrets: secrets) {
+        sh '''
+            if [ "$MULTILINE_SECRET" = "$(cat << EOF
+-----BEGIN PRIVATE KEY-----
+RGVhciBzZWN1cml0eSByZXNlYXJjaGVyLApXaGls
+ZSB3ZSBkZWVwbHkgYXBwcmVjaWF0ZSB5b3VyIHZp
+Z2lsYW5jZSBhbmQgZWZmb3J0cyB0byBtYWtlIHRo
+ZSB3b3JsZCBtb3JlIHNlY3VyZSwgSSdtIGFmcmFp
+ZCBJIG11c3QgdGVsbCB5b3UgdGhhdCB0aGlzIHZh
+bHVlIGlzIG5vdCBhIGFjdHVhbCBwcml2YXRlIGtl
+eS4gCkl0J3MgYSBqdXN0IGEgZHVtbXkgc2VjcmV0
+IHRoYXQgd2UgdXNlIHRvIHRlc3QgdmFyaW91cyAx
+UGFzc3dvcmQgc2VjcmV0cyBpbnRlZ3JhdGlvbnMu
+IApTbyBwbGVhc2UgZG9uJ3QgcmVwb3J0IGl0IQo=
+-----END PRIVATE KEY-----
+EOF
+)" ]; then
+                echo "Strings are equal."
+            else
+                echo "Strings are not equal."
+            fi
+        '''
+    }
+}


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

This PR reads the entire secret value from 1Password instead of just the first line of it. This ensures that multiline secrets are properly pulled. 

Resolves #10 

The fix is changing line 129 in `src/main/java/com/onepassword/jenkins/plugins/OnePasswordAccessor.java` in from:

```java
String secretValue = stdInput.readLine();
```

which was *only* reading the firs line of the secret, to:

```
String secretValue = stdInput.lines().collect(Collectors.joining(System.lineSeparator()));
```

which reads all the lines of the secret and preserves the newlines in it.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

Testing has been done by:
- Adding a new test case which validates the fix
- Running the plugin locally and validating that multiline secrets are properly parsed.

#### For reviewers

1. Checkout this branch:
   
   ```sh
   git pull && git checkout bugfix/multiline-secrets
   ```

2. Run the plugin:

   ```sh
   mvn hpi:run
   ```

3. Create a new pipeline with the following script:

   ```groovy
   def config = [
           // Configure to use either a Connect server or a service account
   ]

   def secrets = [
           [envVar: 'MULTILINE_SECRET', secretRef: '<op://vault/item/multiline-secret>'],
   ]

   node {
       sh '''
           CLI_VERSION="v$(curl https://app-updates.agilebits.com/check/1/0/CLI2/en/2.0.0/N -s | grep -Eo '[0-9]+\\.[0-9]+\\.[0-9]+')"
           curl -sSfLo op.zip https://cache.agilebits.com/dist/1P/op2/pkg/$CLI_VERSION/op_darwin_arm64_$CLI_VERSION.zip && unzip -o op.zip && rm op.zip
       '''
       withSecrets(config: config, secrets: secrets) {
          sh '''
              if [ "$MULTILINE_SECRET" = "$(cat << EOF
   <your-multiline-secret>
   )" ]; then
                  echo "Strings are equal."
              else
                  echo "Strings are not equal."
              fi
          '''
       }
   }
   ```

   For addition details about creating Jenkins pipeline using the plugin and configuring the plugin, check [the documentation](https://developer.1password.com/docs/ci-cd/jenkins/).

4. Run the pipeline.
   - [ ] It should succeed.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
