### PR TITLE
Issue #16: Fix secure notes and multi-line fields being displayed in job logs

### DIFF
--- a/src/main/java/com/onepassword/jenkins/plugins/log/MaskingConsoleLogFilter.java
+++ b/src/main/java/com/onepassword/jenkins/plugins/log/MaskingConsoleLogFilter.java
@@ -13,6 +13,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.ArrayList;
+import java.util.Arrays;
 
 /* The class is borrowed from https://github.com/jenkinsci/hashicorp-vault-plugin/ */
 public class MaskingConsoleLogFilter extends ConsoleLogFilter
@@ -38,7 +40,12 @@ public class MaskingConsoleLogFilter extends ConsoleLogFilter
 
             @Override
             protected void eol(byte[] b, int len) throws IOException {
-                p = Pattern.compile(getPatternStringForSecrets(valuesToMask));
+                List<String> splitValuesToMask = new ArrayList<String>();
+                for (String valueToMask : valuesToMask) {
+                    List<String> splitValues = new ArrayList<String>(Arrays.asList(valueToMask.split("\n")));
+                    splitValuesToMask.addAll(splitValues);
+                }
+                p = Pattern.compile(getPatternStringForSecrets(splitValuesToMask));
                 if (StringUtils.isBlank(p.pattern())) {
                     logger.write(b, 0, len);
                     return;

--- a/src/test/java/com/onepassword/jenkins/plugins/OnePasswordWithSecretsTest.java
+++ b/src/test/java/com/onepassword/jenkins/plugins/OnePasswordWithSecretsTest.java
@@ -120,4 +120,19 @@ public class OnePasswordWithSecretsTest {
         WorkflowRun build = j.buildAndAssertSuccess(project);
         j.assertLogNotContains(TEST_SECRET, build);
     }
+
+    @Test
+    public void testSecretsMultilineMasked() throws Exception {
+        WorkflowJob project = j.createProject(WorkflowJob.class);
+        project.setDefinition(new CpsFlowDefinition(readFile(basePath + "testSecretsMultilineMasked.groovy",
+                Charset.defaultCharset())
+                .replace("OP_HOST", TEST_CONNECT_HOST)
+                .replace("OP_CLI_URL", OP_CLI_URL),
+                true));
+
+        WorkflowRun build = j.buildAndAssertSuccess(project);
+        j.assertLogNotContains("-----BEGIN PRIVATE KEY-----", build);
+        j.assertLogNotContains("RGVhciBzZWN1cml0eSByZXNlYXJjaGVyLApXaGls", build);
+        j.assertLogNotContains("-----END PRIVATE KEY-----", build);
+    }
 }

--- a/src/test/resources/com/onepassword/jenkins/plugins/pipeline/testSecretsMulitlineMasked.groovy
+++ b/src/test/resources/com/onepassword/jenkins/plugins/pipeline/testSecretsMulitlineMasked.groovy
@@ -1,0 +1,18 @@
+def config = [
+    connectHost: "OP_HOST",
+    connectCredentialId: "connect-credential-id"
+]
+
+def secrets = [
+    [envVar: 'MULTILINE_SECRET', secretRef: 'op://acceptance-tests/multiline-secret/notesPlain'],
+]
+
+node {
+    sh 'curl -sSfLo op.zip OP_CLI_URL && unzip -o op.zip && rm op.zip'
+    withSecrets(config: config, secrets: secrets) {
+        sh '''
+            echo $MULTILINE_SECRET
+            echo "not sensitive data"
+        '''
+    }
+}


### PR DESCRIPTION
Fixes #16

### Testing done

Tested with private keys, secure notes, and passwords
![image](https://github.com/user-attachments/assets/68a14138-53f4-4784-936e-f5dbd88f5f50)
![image](https://github.com/user-attachments/assets/5343a86f-de45-42b2-838d-9fa37542c50a)


<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
