### PR TITLE
Update README.md to fix broken link to service account docs webpage

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ If you're using 1Password Connect, then you'll need to:
 - [Set up a Secrets Automation workflow](https://developer.1password.com/docs/connect/get-started#step-1-set-up-a-secrets-automation-workflow).
 - [Deploy 1Password Connect](https://developer.1password.com/docs/connect/get-started#step-2-deploy-1password-connect-server) in your infrastructure.
 
-If you're using 1Password Service Accounts, then you'll need to [create a service account](https://developer.1password.com//docs/service-accounts/).
+If you're using 1Password Service Accounts, then you'll need to [create a service account](https://developer.1password.com/docs/service-accounts/).
 
 ## Install the 1Password CLI
 


### PR DESCRIPTION
When viewing https://plugins.jenkins.io/onepassword-secrets/, i wanted to know how to set up a 1Password service account, so i clicked the link referred to by this PR, which showed the following error (appears to be a red herring / AWS S3 error):

```
This XML file does not appear to have any style information associated with it. The document tree is shown below.
<Error>
<Code>AccessDenied</Code>
<Message>Access Denied</Message>
<RequestId>RMSBB78HHB537NWH</RequestId>
<HostId>H2hzdNFKJBZi35xBjbaKNgsPjNL1JK12kr6OY9ohhv4t6qESH057nmTa6Wafixs1Jx1DXzHTy1y2ir1TGgHCbA==</HostId>
</Error>
```

### Testing done

I removed the extra `/` char in the URL and pasted the result into a web browser tab, causing the 1Password documentation page to be rendered as expected.

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
