### PR TITLE
Fixed Windows Compatibility (fix for #23)

### DIFF
--- a/src/main/java/com/onepassword/jenkins/plugins/OnePasswordAccessor.java
+++ b/src/main/java/com/onepassword/jenkins/plugins/OnePasswordAccessor.java
@@ -121,8 +121,12 @@ public class OnePasswordAccessor implements Serializable {
         pb.directory(new File(opCLIPath));
 
         for (OnePasswordSecret secret : secrets) {
+
             logger.printf("Retrieving secret %s%n", secret.getEnvVar());
-            String[] commands = {opCLIPath + "/op", "read", secret.getSecretRef()};
+            String opCliExecutablePath = opCLIPath.toLowerCase().endsWith(".exe")
+                ? opCLIPath
+                : opCLIPath + "/op";
+            String[] commands = {opCliExecutablePath, "read", secret.getSecretRef()};
             try {
                 Process pr = pb.command(commands).start();
                 BufferedReader stdInput = new BufferedReader(new InputStreamReader(pr.getInputStream(), StandardCharsets.UTF_8));


### PR DESCRIPTION
This is a fix for #23.
I added a check if the `OP_CLI_PATH` ends in ".exe" indictating a path to a Windows program. If that's the case `/op` will not be appended to the executable path. Any executables on Windows will have the ".exe" extension. 

### Testing done
Not yet completed.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
